### PR TITLE
Milestone: Room Lock

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -31,7 +31,8 @@ create table rooms (
   language text not null,
   starter_code text not null,
   groups json not null,
-  created timestamptz not null default now()
+  created timestamptz not null default now(),
+  lock_time timestamptz
 );
 ```
 

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -31,7 +31,7 @@ create table rooms (
   language text not null,
   starter_code text not null,
   groups json not null,
-  created timestamp not null
+  created timestamptz not null default now()
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![A image showcasing what a student sees when they join a group](doc/demo.png)
+[![A image showcasing what a student sees when they join a group](doc/demo.png)](https://106b.vercel.app)
 
 # `bcode`
 
@@ -6,14 +6,14 @@
 
 `bcode` is a tool that enables Stanford section leaders to create collaborative small group problems during section. Hosts create **rooms** with one or more **groups** that students can join to collaboratively write code during section. Think of it like breakout rooms for code.
 
-To start using `bcode` for your section, [sign in through GitHub ](https://106b.vercel.app) and create a room! Once a room is created, you'll be able to share the link and QR code with your sectionees.
+To start using `bcode` for your section, [sign in through GitHub](https://106b.vercel.app) and create a room! Once a room is created, you'll be able to share the link and QR code with your sectionees.
 
 ## Milestones
 
 - [x] Add stricter authentication checks 🛡️
 - [x] Add support for Python syntax highlighting (for CS106A) 🐍
 - [x] Add support for starter code (avoid multiple copy/paste) 📜
-- [ ] Add support for locking rooms 🔒
+- [x] Add support for locking rooms 🔒
 
 ## Hosting
 

--- a/src/app/[room]/GuestView.tsx
+++ b/src/app/[room]/GuestView.tsx
@@ -203,6 +203,7 @@ function GuestViewTitle({ room, view }: { room: Room; view: GuestViewStatus }) {
         display="inline"
         variant="inherit"
         fontWeight={view === GuestViewStatus.Name ? 500 : undefined}
+        iconSize="0.6em"
       />
     </Typography>
   );

--- a/src/app/[room]/GuestView.tsx
+++ b/src/app/[room]/GuestView.tsx
@@ -31,6 +31,7 @@ import { z } from "zod";
 import { toFormikValidationSchema } from "zod-formik-adapter";
 import { ConnectionStatus } from "@/types/Connection";
 import { random } from "lodash";
+import { RoomTitle } from "@/components/RoomTitle";
 
 /**
  * Available colors for guests to use.
@@ -196,9 +197,13 @@ function GuestViewTitle({ room, view }: { room: Room; view: GuestViewStatus }) {
   return (
     <Typography variant="h5">
       {view === GuestViewStatus.Name && "Join "}
-      <Typography display="inline" variant="inherit" fontWeight={view === GuestViewStatus.Name ? 500 : undefined}>
-        {room.name}
-      </Typography>
+      <RoomTitle
+        room={room}
+        host={false}
+        display="inline"
+        variant="inherit"
+        fontWeight={view === GuestViewStatus.Name ? 500 : undefined}
+      />
     </Typography>
   );
 }

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -12,7 +12,7 @@
  */
 
 import createServer from "@/provider/server";
-import { RoomChannelEvents } from "@/state/events";
+import { ChannelEvents } from "@/provider/events";
 import { Room, RoomGroup, RoomSchema, channelMask, channelString, parseChannelString } from "@/types/Room";
 import { difference } from "lodash";
 import { revalidatePath } from "next/cache";
@@ -124,7 +124,7 @@ async function notifyParticipants(code: string) {
   /* Send update message */
   const result = await channel.send({
     type: "broadcast",
-    event: RoomChannelEvents.Update,
+    event: ChannelEvents.Update,
   });
 
   if (result !== "ok") throw new Error(`Failed to update participants: ${result}`);

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -330,7 +330,7 @@ export async function upsertRoom(room: Room) {
     /* Get existing room with this code, if any */
     const { data: existing } = await supabase
       .from(Tables.Rooms)
-      .select("owner, starter_code, created, groups")
+      .select("owner, starter_code, groups")
       .eq("code", room.code)
       .maybeSingle()
       .throwOnError();
@@ -339,8 +339,8 @@ export async function upsertRoom(room: Room) {
     if (existing && existing.owner != owner) return failure(401, "Unauthorized");
 
     /* Upsert room to database */
-    const row = { owner, ...room };
-    row.created = existing ? existing.created : new Date().toISOString();
+    const { created, ...rest } = room;
+    const row = { owner, ...rest };
     if (existing) await supabase.from(Tables.Rooms).update(row).eq("code", room.code).throwOnError();
     else await supabase.from(Tables.Rooms).insert(row).throwOnError();
 

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -13,11 +13,17 @@
 
 import createServer from "@/provider/server";
 import { RoomChannelEvents } from "@/state/events";
-import { Room, RoomSchema, channelMask, channelString, parseChannelString } from "@/types/Room";
+import { Room, RoomGroup, RoomSchema, channelMask, channelString, parseChannelString } from "@/types/Room";
 import { difference } from "lodash";
 import { revalidatePath } from "next/cache";
 import { notFound } from "next/navigation";
 import { decodeUpdateV2, mergeUpdatesV2, Doc, encodeStateAsUpdateV2 } from "yjs";
+
+/**
+ * Millisecond grace period when saving updates to a room that is locked.
+ * See the comment in {@link saveDocument} for more information.
+ */
+const LockSaveGracePeriodMs = 5000;
 
 /*
  * ============================================================================
@@ -140,11 +146,31 @@ export async function saveDocument(channel: string, update: number[]): Promise<v
    * and has the specified group number.
    */
 
+  const updateTs = new Date();
   const [code, group] = parseChannelString(channel);
-  const { data: room, error } = await getRoom(code);
-  if (error) throw new Error(error.message);
+
+  const supabase = createServer();
+  const { data: room } = await supabase.from(Tables.Rooms)
+    .select("groups, lock_time, owner")
+    .eq("code", code)
+    .maybeSingle()
+    .throwOnError();
+
   if (!room) throw new Error("No such room");
-  if (!room.groups.some((g) => g.no === group)) throw new Error("No such group in room");
+  if (!room.groups.some((g: RoomGroup) => g.no === group)) throw new Error("No such group in room");
+
+  /* Authorize user.
+   * 
+   * If the room is unlocked, always allow updates.
+   * If the room is locked, always allow updates if requester is the host.
+   * Otherwise, only allow updates if they are made within a grace period of the time that
+   * the room was locked. This policy ensures that lingering updates made at the moment the room
+   * was locked are saved to the database, but any updates thereafter are rejected.
+   */
+  if (room.lock_time && (await getUser()) !== room.owner) {
+    const lockTs = new Date(room.lock_time);
+    if (updateTs.getTime() - lockTs.getTime() > LockSaveGracePeriodMs) throw new Error("Room is locked");
+  }
 
   /*
    * Validate YJS update by calling `decodeUpdate`. If YJS throws an error
@@ -196,7 +222,7 @@ export async function getRooms(code?: string) {
     const supabase = createServer();
     let query = supabase
       .from(Tables.Rooms)
-      .select("code, name, language, starter_code, groups, created")
+      .select("code, name, language, starter_code, groups, created, lock_time")
       .throwOnError();
     if (code !== undefined) query = query.eq("code", code);
     else {
@@ -207,7 +233,14 @@ export async function getRooms(code?: string) {
     }
 
     const { data } = await query;
-    return success(data!.map((d) => ({ ...d, created: new Date(d.created).toISOString() })) as Room[]);
+    return success(
+      data!.map((d) => ({
+        ...d,
+        created: new Date(d.created).toISOString(),
+        lock_time: undefined,
+        locked: !!d.lock_time,
+      })) as Room[]
+    );
   } catch (err: any) {
     return failure(500, err.message);
   }
@@ -330,7 +363,7 @@ export async function upsertRoom(room: Room) {
     /* Get existing room with this code, if any */
     const { data: existing } = await supabase
       .from(Tables.Rooms)
-      .select("owner, starter_code, groups")
+      .select("owner, starter_code, groups, lock_time")
       .eq("code", room.code)
       .maybeSingle()
       .throwOnError();
@@ -339,8 +372,13 @@ export async function upsertRoom(room: Room) {
     if (existing && existing.owner != owner) return failure(401, "Unauthorized");
 
     /* Upsert room to database */
-    const { created, ...rest } = room;
-    const row = { owner, ...rest };
+    const { created, locked, ...rest } = room;
+    const row = {
+      owner,
+      lock_time: room.locked ? existing?.lock_time || new Date().toISOString() : null,
+      ...rest,
+    };
+
     if (existing) await supabase.from(Tables.Rooms).update(row).eq("code", room.code).throwOnError();
     else await supabase.from(Tables.Rooms).insert(row).throwOnError();
 

--- a/src/app/rooms/RoomSidebar.tsx
+++ b/src/app/rooms/RoomSidebar.tsx
@@ -140,6 +140,7 @@ export function AddRoomButton() {
           starter_code: "",
           groups: groupsForCount(1),
           created: new Date().toISOString(),
+          locked: false
         }}
       />
       <IconButton onClick={() => setOpen(true)}>

--- a/src/app/rooms/RoomSidebarInput.tsx
+++ b/src/app/rooms/RoomSidebarInput.tsx
@@ -16,6 +16,9 @@ import {
   useMediaQuery,
   useTheme,
   TooltipProps,
+  FormGroup,
+  FormControlLabel,
+  Switch,
 } from "@mui/material";
 import { useFormikContext } from "formik";
 import { debounce, isEqual } from "lodash";
@@ -196,6 +199,17 @@ export default function RoomSidebarInput() {
           any code that has been written for this room.
         </Alert>
       </Collapse>
+
+      <Stack direction="row" spacing={1} justifyContent="space-between" alignItems="center">
+        <Stack>
+          <Typography variant="subtitle2">Lock Room</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Prevent guests from modifying the room
+          </Typography>
+        </Stack>
+        <Switch defaultChecked />
+      </Stack>
+
       <LoadingButton
         variant="outlined"
         size="large"

--- a/src/app/rooms/RoomSidebarInput.tsx
+++ b/src/app/rooms/RoomSidebarInput.tsx
@@ -16,8 +16,6 @@ import {
   useMediaQuery,
   useTheme,
   TooltipProps,
-  FormGroup,
-  FormControlLabel,
   Switch,
 } from "@mui/material";
 import { useFormikContext } from "formik";
@@ -204,10 +202,16 @@ export default function RoomSidebarInput() {
         <Stack>
           <Typography variant="subtitle2">Lock Room</Typography>
           <Typography variant="caption" color="text.secondary">
-            Prevent guests from modifying the room
+            Prevent guests from making changes to the room
           </Typography>
         </Stack>
-        <Switch defaultChecked />
+        <Stack direction="row" alignItems="center">
+          <Switch
+            defaultChecked
+            checked={formik.values.locked}
+            onChange={(e) => formik.setFieldValue("locked", e.target.checked)}
+          />
+        </Stack>
       </Stack>
 
       <LoadingButton

--- a/src/app/rooms/[room]/page.tsx
+++ b/src/app/rooms/[room]/page.tsx
@@ -20,7 +20,7 @@ export default async function HostRoomPage({ params }: { params: { room: string 
   return (
     <Stack spacing={2}>
       <Stack spacing={1}>
-        <Stack direction={{ xs: "column", md: "row" }} justifyContent="space-between" alignItems="start" spacing={2}>
+        <Stack direction={{ xs: "column", md: "row" }} justifyContent="space-between" alignItems="start" spacing={1}>
           <Stack spacing={1}>
             <RoomTitle room={room} host={true} variant="h4" />
             <Typography fontFamily={courier.style.fontFamily} variant="h5">

--- a/src/app/rooms/[room]/page.tsx
+++ b/src/app/rooms/[room]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import SquaresIcon from "@heroicons/react/24/outline/Squares2X2Icon";
 import EditorOnline from "@/components/code/EditorOnline";
 import { getPageRoom } from "@/app/actions";
+import { RoomTitle } from "@/components/RoomTitle";
 
 export async function generateMetadata({ params }: { params: { room: string } }) {
   const room = await getPageRoom(params.room);
@@ -21,7 +22,7 @@ export default async function HostRoomPage({ params }: { params: { room: string 
       <Stack spacing={1}>
         <Stack direction={{ xs: "column", md: "row" }} justifyContent="space-between" alignItems="start" spacing={2}>
           <Stack spacing={1}>
-            <Typography variant="h4">{room.name}</Typography>
+            <RoomTitle room={room} host={true} variant="h4" />
             <Typography fontFamily={courier.style.fontFamily} variant="h5">
               {room.code}
             </Typography>

--- a/src/components/RoomTitle.tsx
+++ b/src/components/RoomTitle.tsx
@@ -3,11 +3,12 @@ import LockClosed from "@heroicons/react/20/solid/LockClosedIcon";
 import { type Room } from "@/types/Room";
 
 export type RoomTitleProps = TypographyProps & {
+  iconSize?: string | number;
   room: Room;
   host: boolean;
 };
 
-export function RoomTitle({ room, host, ...rest }: RoomTitleProps) {
+export function RoomTitle({ iconSize = "0.5em", room, host, ...rest }: RoomTitleProps) {
   return (
     <Typography component="div" {...rest}>
       <Stack direction="row" spacing={1} alignItems="center" display="inline-flex">
@@ -20,7 +21,7 @@ export function RoomTitle({ room, host, ...rest }: RoomTitleProps) {
             placement="right"
             title={`This room is locked${host ? ". Only you can edit it" : " and can't be modified"}`}
           >
-            <SvgIcon sx={{ fontSize: "0.5em" }}>
+            <SvgIcon sx={{ fontSize: iconSize }}>
               <LockClosed />
             </SvgIcon>
           </Tooltip>

--- a/src/components/RoomTitle.tsx
+++ b/src/components/RoomTitle.tsx
@@ -1,0 +1,31 @@
+import { Stack, SvgIcon, Tooltip, Typography, type TypographyProps } from "@mui/material";
+import LockClosed from "@heroicons/react/20/solid/LockClosedIcon";
+import { type Room } from "@/types/Room";
+
+export type RoomTitleProps = TypographyProps & {
+  room: Room;
+  host: boolean;
+};
+
+export function RoomTitle({ room, host, ...rest }: RoomTitleProps) {
+  return (
+    <Typography component="div" {...rest}>
+      <Stack direction="row" spacing={1} alignItems="center" display="inline-flex">
+        <Typography variant="inherit" fontWeight="inherit">
+          {room.name}
+        </Typography>
+        {room.locked && (
+          <Tooltip
+            arrow
+            placement="right"
+            title={`This room is locked${host ? ". Only you can edit it" : " and can't be modified"}`}
+          >
+            <SvgIcon sx={{ fontSize: "0.5em" }}>
+              <LockClosed />
+            </SvgIcon>
+          </Tooltip>
+        )}
+      </Stack>
+    </Typography>
+  );
+}

--- a/src/components/ThemeRegistry/theme.ts
+++ b/src/components/ThemeRegistry/theme.ts
@@ -1,4 +1,4 @@
-import { PaletteOptions, createTheme as createMuiTheme } from "@mui/material/styles";
+import { alpha, createTheme as createMuiTheme } from "@mui/material/styles";
 import { jakarta } from "./fonts";
 
 declare module "@mui/material/styles" {
@@ -21,26 +21,32 @@ export default function createTheme(mode: "light" | "dark") {
       mode,
       ...(mode === "light"
         ? {
-            primary: { main: "rgba(0, 0, 0, 0.6)" },
+            primary: { main: "rgba(70, 70, 70, 1.0)" },
             text: {
               primary: "rgba(0, 0, 0, 0.6)",
-              secondary: "rgba(0, 0, 0, 0.26)",
+              secondary: "rgba(0, 0, 0, 0.46)",
             },
             editor: { main: "#fcfcfc" },
             background: { contrast: "#000" },
           }
         : {
-            primary: { main: "rgba(255, 255, 255, 0.8)" },
+            primary: { main: "rgba(225, 225, 225, 1.0)" },
             text: {
               primary: "rgba(255, 255, 255, 0.8)",
               secondary: "rgba(255, 255, 255, 0.46)",
             },
             editor: { main: "#141414" },
-            background: { contrast: "#fff" },
+            background: {
+              contrast: "#fff",
+              paper: "rgb(22, 22, 22)",
+            },
           }),
     },
     typography: {
       fontFamily: jakarta.style.fontFamily,
+    },
+    shape: {
+      borderRadius: 9,
     },
   });
 
@@ -51,15 +57,6 @@ export default function createTheme(mode: "light" | "dark") {
         root: {
           backgroundImage: "unset",
         },
-      },
-    },
-    MuiAlert: {
-      styleOverrides: {
-        root: ({ ownerState }) => ({
-          ...(ownerState.severity === "info" && {
-            backgroundColor: "#60a5fa",
-          }),
-        }),
       },
     },
     MuiButton: {
@@ -73,7 +70,6 @@ export default function createTheme(mode: "light" | "dark") {
       styleOverrides: {
         root: {
           boxShadow: "0 2px 6px rgba(0,0,0,.05)",
-          borderRadius: "10px",
           ["&.Mui-focused"]: {
             ["& .MuiOutlinedInput-notchedOutline"]: {
               borderWidth: 1,
@@ -92,13 +88,6 @@ export default function createTheme(mode: "light" | "dark") {
         },
       },
     },
-    MuiButtonBase: {
-      styleOverrides: {
-        root: {
-          borderRadius: "10px !important",
-        },
-      },
-    },
     MuiMenuItem: {
       styleOverrides: {
         root: {
@@ -106,25 +95,11 @@ export default function createTheme(mode: "light" | "dark") {
         },
       },
     },
-    MuiSlider: {
-      styleOverrides: {
-        thumb: {
-          color: theme.palette.background.contrast,
-        },
-      },
-    },
     MuiAvatar: {
       styleOverrides: {
         root: {
           fontSize: "1rem",
-          color: "white"
-        },
-      },
-    },
-    MuiDialog: {
-      styleOverrides: {
-        paper: {
-          borderRadius: "10px",
+          color: "white",
         },
       },
     },

--- a/src/components/ThemeRegistry/theme.ts
+++ b/src/components/ThemeRegistry/theme.ts
@@ -103,6 +103,15 @@ export default function createTheme(mode: "light" | "dark") {
         },
       },
     },
+    MuiSwitch: {
+      styleOverrides: {
+        root: {
+          "& :not(.Mui-checked) > .MuiSwitch-thumb": {
+            backgroundColor: theme.palette.augmentColor({ color: { main: theme.palette.background.paper } }).light,
+          },
+        },
+      },
+    },
   };
 
   return theme;

--- a/src/components/code/EditorBase.tsx
+++ b/src/components/code/EditorBase.tsx
@@ -47,10 +47,16 @@ export type EditorConfig = {
    * number of characters.
    */
   notifyMax?: boolean;
+
+  /**
+   * Whether or not modifying the document is allowed. User will still be allowed to select and copy.
+   */
+  readOnly?: boolean;
 };
 
 const EditorTheme = new Compartment();
 const EditorLanguage = new Compartment();
+const EditorReadOnly = new Compartment();
 
 /**
  * Checks if a transaction is remote.
@@ -139,6 +145,7 @@ export function useEditor(config: EditorConfig) {
           keymap.of([indentWithTab]),
           EditorTheme.of(editorTheme),
           EditorLanguage.of([]),
+          EditorReadOnly.of(EditorState.readOnly.of(!!config.readOnly)),
           maxLength(config.max, config.notifyMax ?? false),
         ].concat(extensions ?? []),
         ...rest,
@@ -151,6 +158,13 @@ export function useEditor(config: EditorConfig) {
       setEditorView(undefined);
     };
   }, [config.onCreate]);
+
+  /* Update the editor when read-only mode changes */
+  useEffect(() => {
+    editorView?.dispatch({
+      effects: EditorReadOnly.reconfigure(EditorState.readOnly.of(!!config.readOnly)),
+    });
+  }, [config.readOnly]);
 
   /* Update the editor theme when the MUI theme changes */
   useEffect(() => {

--- a/src/components/code/RoomEditor.tsx
+++ b/src/components/code/RoomEditor.tsx
@@ -4,6 +4,7 @@ import { CardHeader, Stack, Typography, alpha } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
 import createClient from "@/provider/client";
 import * as Y from "yjs";
+import * as AwarenessProtocol from "y-protocols/awareness";
 import { ReadWriteMode, SupabaseProvider, SupabaseProviderEvents } from "@/provider";
 import { yCollab } from "y-codemirror.next";
 import EditorFrame, { EditorFrameProps } from "./EditorFrame";
@@ -87,6 +88,7 @@ function useSaved() {
 }
 
 function updateProviderUser(provider: SupabaseProvider, user: LiveUser) {
+  if (!provider.awareness.getLocalState()) provider.awareness.setLocalState({});
   provider.awareness.setLocalStateField("user", {
     name: user.name,
     color: user.color,
@@ -202,6 +204,9 @@ export default function RoomEditor({ room, group, action }: RoomEditorProps) {
   /* Update provider read-only mode when read-only changes */
   useEffect(() => {
     if (!provider.current) return;
+    const awareness = provider.current.awareness;
+    if (readOnly) AwarenessProtocol.removeAwarenessStates(awareness, [awareness.clientID], null);
+    else updateProviderUser(provider.current, user);
     provider.current.config.rw = readOnly ? ReadWriteMode.ReadOnly : ReadWriteMode.ReadWrite;
   }, [readOnly]);
 

--- a/src/components/code/RoomEditor.tsx
+++ b/src/components/code/RoomEditor.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { CardHeader, Stack, Typography, alpha, useTheme } from "@mui/material";
+import { CardHeader, Stack, SvgIcon, Tooltip, Typography, alpha } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
 import createClient from "@/provider/client";
 import * as Y from "yjs";
-import { SupabaseProvider, SupabaseProviderEvents } from "@/provider";
+import { ReadWriteMode, SupabaseProvider, SupabaseProviderEvents } from "@/provider";
 import { yCollab } from "y-codemirror.next";
 import EditorFrame, { EditorFrameProps } from "./EditorFrame";
 import { ConnectionStatus } from "@/types/Connection";
@@ -17,6 +17,7 @@ import { EditorStyles, useEditor } from "./EditorBase";
 import { closeSnackbar, enqueueSnackbar } from "notistack";
 import { useRoomState } from "@/state/room";
 import { prod } from "@/app/util";
+import LockClosed from "@heroicons/react/20/solid/LockClosedIcon";
 
 /*
  * ============================================================================
@@ -100,11 +101,18 @@ function updateProviderUser(provider: SupabaseProvider, user: LiveUser) {
  * ============================================================================
  */
 
-function EditorTitle({ group, saving }: { group?: RoomGroup; saving?: boolean }) {
-  const theme = useTheme();
+function EditorTitle({ room, group, saving }: { room: Room; group?: RoomGroup; saving?: boolean }) {
+  const isHost = useUserState((state) => state.user.isHost);
   return (
     <Stack direction="row" alignItems="center" spacing={1}>
       <Typography variant="inherit">{group?.name}</Typography>
+      {room.locked && (
+        <Tooltip arrow title={`The room has been locked${isHost ? ". Only you can edit it" : ""}`}>
+          <SvgIcon sx={{ fontSize: "0.66em" }}>
+            <LockClosed />
+          </SvgIcon>
+        </Tooltip>
+      )}
       <Typography
         variant="caption"
         color="text.secondary"
@@ -138,11 +146,13 @@ export default function RoomEditor({ room, group, action }: RoomEditorProps) {
 
   const channel = channelString(room, group);
   const editorId = `${kEditorViewId}-${channel}`;
+  const readOnly = !user.isHost && room.locked;
 
   useEditor({
     language: room.language,
     max: kEditorMaxChars,
     notifyMax: true,
+    readOnly,
 
     onCreate: useCallback(() => {
       // If we are waiting to reload the editor, do nothing.
@@ -158,6 +168,7 @@ export default function RoomEditor({ room, group, action }: RoomEditorProps) {
       provider.current = new SupabaseProvider(ydoc, supabase, {
         channel,
         log: !prod(),
+        rw: readOnly ? ReadWriteMode.ReadOnly : ReadWriteMode.ReadWrite,
 
         async loadDocument() {
           const state = await loadDocument(channel);
@@ -195,6 +206,12 @@ export default function RoomEditor({ room, group, action }: RoomEditorProps) {
       setSaving(false, false);
     },
   });
+
+  /* Update provider read-only mode when read-only changes */
+  useEffect(() => {
+    if (!provider.current) return;
+    provider.current.config.rw = readOnly ? ReadWriteMode.ReadOnly : ReadWriteMode.ReadWrite;
+  }, [readOnly]);
 
   /* Update the awareness user other people see (cursor color, name, etc.) if it changes */
   useEffect(() => {
@@ -248,7 +265,7 @@ export default function RoomEditor({ room, group, action }: RoomEditorProps) {
   return (
     <EditorFrame sx={{ minHeight: kEditorHeightPx }}>
       <CardHeader
-        title={<EditorTitle group={room?.groups.find((g) => g.no === group)} saving={saving} />}
+        title={<EditorTitle room={room} group={room?.groups.find((g) => g.no === group)} saving={saving} />}
         titleTypographyProps={{ variant: "h6", fontWeight: 400 }}
         action={
           <Stack direction="row" alignItems="center" spacing={1}>

--- a/src/components/code/RoomEditor.tsx
+++ b/src/components/code/RoomEditor.tsx
@@ -169,6 +169,7 @@ export default function RoomEditor({ room, group, action }: RoomEditorProps) {
         channel,
         log: !prod(),
         rw: readOnly ? ReadWriteMode.ReadOnly : ReadWriteMode.ReadWrite,
+        throttleInterval: 200,
 
         async loadDocument() {
           const state = await loadDocument(channel);

--- a/src/components/code/RoomEditor.tsx
+++ b/src/components/code/RoomEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CardHeader, Stack, SvgIcon, Tooltip, Typography, alpha } from "@mui/material";
+import { CardHeader, Stack, Typography, alpha } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
 import createClient from "@/provider/client";
 import * as Y from "yjs";
@@ -17,7 +17,6 @@ import { EditorStyles, useEditor } from "./EditorBase";
 import { closeSnackbar, enqueueSnackbar } from "notistack";
 import { useRoomState } from "@/state/room";
 import { prod } from "@/app/util";
-import LockClosed from "@heroicons/react/20/solid/LockClosedIcon";
 
 /*
  * ============================================================================
@@ -101,18 +100,10 @@ function updateProviderUser(provider: SupabaseProvider, user: LiveUser) {
  * ============================================================================
  */
 
-function EditorTitle({ room, group, saving }: { room: Room; group?: RoomGroup; saving?: boolean }) {
-  const isHost = useUserState((state) => state.user.isHost);
+function EditorTitle({ group, saving }: { group?: RoomGroup; saving?: boolean }) {
   return (
     <Stack direction="row" alignItems="center" spacing={1}>
       <Typography variant="inherit">{group?.name}</Typography>
-      {room.locked && (
-        <Tooltip arrow title={`The room has been locked${isHost ? ". Only you can edit it" : ""}`}>
-          <SvgIcon sx={{ fontSize: "0.66em" }}>
-            <LockClosed />
-          </SvgIcon>
-        </Tooltip>
-      )}
       <Typography
         variant="caption"
         color="text.secondary"
@@ -266,7 +257,7 @@ export default function RoomEditor({ room, group, action }: RoomEditorProps) {
   return (
     <EditorFrame sx={{ minHeight: kEditorHeightPx }}>
       <CardHeader
-        title={<EditorTitle room={room} group={room?.groups.find((g) => g.no === group)} saving={saving} />}
+        title={<EditorTitle group={room?.groups.find((g) => g.no === group)} saving={saving} />}
         titleTypographyProps={{ variant: "h6", fontWeight: 400 }}
         action={
           <Stack direction="row" alignItems="center" spacing={1}>

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -2,7 +2,6 @@ import { createBrowserClient } from "@supabase/ssr";
 
 export default function createClient() {
   return createBrowserClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
-    realtime: { params: { eventsPerSecond: 5 } },
     cookies: {},
   });
 }

--- a/src/provider/events.ts
+++ b/src/provider/events.ts
@@ -1,0 +1,3 @@
+export enum ChannelEvents {
+  Update = "update",
+}

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -405,7 +405,13 @@ export class SupabaseProvider extends EventEmitter {
   private sendUpdate(update: { document?: Uint8Array; awareness?: number[]; resync?: boolean }) {
     if (!update.resync && this.config.rw === ReadWriteMode.ReadOnly) return;
     if (update.resync && !this.config.resync) return;
-    if (update.resync) update = { document: Y.encodeStateAsUpdate(this.doc) };
+    if (update.resync) {
+      update = {
+        document: Y.encodeStateAsUpdate(this.doc),
+        awareness: [this.awareness.clientID],
+      };
+    }
+
     if (!update.document && (!update.awareness || update.awareness.length === 0)) return;
     if (update.document) this.documentUpdates.push(update.document);
     if (update.awareness) this.awarenessUpdates.push(...update.awareness);

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -4,7 +4,9 @@ import * as AwarenessProtocol from "y-protocols/awareness";
 import EventEmitter from "events";
 import debug, { Debugger } from "debug";
 import { ConnectionStatus } from "@/types/Connection";
-import { debounce, defaults } from "lodash";
+import { debounce, defaults, throttle, uniq } from "lodash";
+import { z } from "zod";
+import { ChannelEvents } from "./events";
 
 const DefaultResyncMs = 20000;
 const DefaultSaveMs = 2500;
@@ -18,7 +20,7 @@ export enum ReadWriteMode {
   /**
    * Document is read only. Changes won't be propogated to peers.
    */
-  ReadOnly
+  ReadOnly,
 }
 
 export type SupabaseProviderConfig = {
@@ -64,6 +66,14 @@ export type SupabaseProviderConfig = {
   readonly saveInterval: number;
 
   /**
+   * Realtime update throttle interval.
+   * At most one realtime message will be sent per this time interval in milliseconds.
+   * `0` will disable message throttling;
+   * @default 0
+   */
+  readonly throttleInterval: number;
+
+  /**
    * Whether or not the provider should log status updates to the console.
    * @default true
    */
@@ -92,13 +102,16 @@ export enum SupabaseProviderEvents {
   Saving = "saving",
 }
 
-enum ChannelEvents {
-  Message = "message",
-  Awareness = "awareness",
-}
-
 type PartialExcept<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
 type ProviderConfig = PartialExcept<SupabaseProviderConfig, "channel">;
+
+const ByteArraySchema = z.number().int().min(0).max(255).array().min(1);
+const PayloadSchema = z.object({
+  document: ByteArraySchema.optional(),
+  awareness: ByteArraySchema.optional(),
+});
+
+type Payload = z.infer<typeof PayloadSchema>;
 
 export class SupabaseProvider extends EventEmitter {
   public readonly config: SupabaseProviderConfig;
@@ -108,7 +121,7 @@ export class SupabaseProvider extends EventEmitter {
   }
 
   public get saving() {
-    return this.saveCounter > 0;
+    return this.savesOutstanding > 0;
   }
 
   constructor(private doc: Y.Doc, private supabase: SupabaseClient, config: ProviderConfig) {
@@ -124,19 +137,13 @@ export class SupabaseProvider extends EventEmitter {
     this.resync = setInterval(this.sendResyncUpdate.bind(this), this.config.resyncInterval);
 
     /* Setup debounced save function */
-    const debouncedSave = debounce(
-      () => this.status === ConnectionStatus.Connected && this.saveDocument(),
-      this.config.saveInterval
-    );
+    this.saveDocument = this.saveDocument.bind(this);
+    this.debouncedSave = debounce(this.saveDocument, this.config.saveInterval);
 
-    this.requestSave = () => {
-      if (this.status !== ConnectionStatus.Connected) return;
-      if (!this.config.save || !this.config.saveDocument) return;
-      const wasSaving = this.saving;
-      this.saveCounter++;
-      if (wasSaving !== this.saving) this.emit(SupabaseProviderEvents.Saving, this, this.saving);
-      debouncedSave();
-    };
+    /* Setup throttled update function */
+    this.commitUpdates = this.commitUpdates.bind(this);
+    if (this.config.throttleInterval === 0) this.throttledSend = this.commitUpdates;
+    else this.throttledSend = throttle(this.commitUpdates, this.config.throttleInterval);
 
     /* Register unload handlers */
     this.onUnload = this.onUnload.bind(this);
@@ -159,11 +166,8 @@ export class SupabaseProvider extends EventEmitter {
     /* Connect client */
     this.channel = this.supabase.channel(this.config.channel);
     this.channel
-      .on("broadcast", { event: ChannelEvents.Message }, ({ payload }) => {
-        this.receiveDocumentUpdate(Uint8Array.from(payload));
-      })
-      .on("broadcast", { event: ChannelEvents.Awareness }, ({ payload }) => {
-        this.receiveAwarenessUpdate(Uint8Array.from(payload));
+      .on("broadcast", { event: ChannelEvents.Update }, ({ payload }) => {
+        this.receiveUpdate(payload);
       })
       .on("presence", { event: "sync" }, () => {
         const state = this.channel!.presenceState();
@@ -177,7 +181,10 @@ export class SupabaseProvider extends EventEmitter {
 
         /* If we're not alone and we received a presence update, then somebody new has joined.
          * We should send them the current state of the document in case our local changes haven't been saved */
-        if (!this.alone) this.sendResyncUpdate();
+        if (!this.alone) {
+          this.sendResyncUpdate();
+          this.commitUpdates();
+        }
       })
       .subscribe((status, err) => {
         switch (status) {
@@ -207,8 +214,14 @@ export class SupabaseProvider extends EventEmitter {
   private resync: NodeJS.Timeout | undefined;
   private previous: Uint8Array | null = null;
   private alone: boolean = true;
-  private saveCounter: number = 0; // The number of outstanding document saves
-  private requestSave: () => void;
+
+  private savesOutstanding: number = 0; // The number of outstanding (incomplete) document saves
+  private savesUnclaimed: number = 0; // The number of save requests waiting to be serviced
+  private debouncedSave: () => void;
+
+  private documentUpdates: Uint8Array[] = [];
+  private awarenessUpdates: number[] = [];
+  private throttledSend: () => void;
 
   private validateConfig(config: ProviderConfig): SupabaseProviderConfig {
     const result = defaults(
@@ -218,8 +231,9 @@ export class SupabaseProvider extends EventEmitter {
         resync: true,
         resyncInterval: DefaultResyncMs,
         saveInterval: DefaultSaveMs,
+        throttleInterval: 0,
         log: true,
-        rw: ReadWriteMode.ReadWrite
+        rw: ReadWriteMode.ReadWrite,
       }
     );
 
@@ -232,13 +246,14 @@ export class SupabaseProvider extends EventEmitter {
   private async destroyInternal(status: ConnectionStatus, error?: any) {
     /* Don't run destruction logic if already destroyed */
     if (this.status === ConnectionStatus.Disconnected || this.status === ConnectionStatus.DisconnectedError) return;
+    this.onUnload();
+    this.commitUpdates();
     this._status = ConnectionStatus.Disconnected;
 
     this.logger(`Destroying ${SupabaseProvider.name} for document ${this.doc.guid}`);
     clearInterval(this.resync);
 
     /* Remove awareness and unregister unload handlers */
-    this.onUnload();
     if (typeof window !== "undefined") {
       window.removeEventListener("beforeunload", this.onUnload);
     } else if (typeof process !== "undefined") {
@@ -246,7 +261,7 @@ export class SupabaseProvider extends EventEmitter {
     }
 
     /* Save any outstanding changes to the document */
-    await this.saveDocument();
+    await this.saveDocument(false);
 
     /* Unbind from document/awareness callbacks */
     this.doc.off("update", this.onDocumentUpdate);
@@ -326,18 +341,30 @@ export class SupabaseProvider extends EventEmitter {
     return true;
   }
 
+  private requestSave() {
+    if (this.status !== ConnectionStatus.Connected) return;
+    if (!this.config.save || !this.config.saveDocument) return;
+    const wasSaving = this.saving;
+    this.savesOutstanding++;
+    this.savesUnclaimed++;
+    if (wasSaving !== this.saving) this.emit(SupabaseProviderEvents.Saving, this, this.saving);
+    this.debouncedSave();
+  }
+
   /**
    * Saves the document remotely to the database.
    * This should be debounced to save on database egress.
    */
-  private async saveDocument() {
-    if (this.saveCounter === 0) return; // Nothing to save
-    const outstandingSaves = this.saveCounter;
+  private async saveDocument(requireConnection: boolean = true) {
+    if (requireConnection && this.status !== ConnectionStatus.Connected) return;
+    if (this.savesUnclaimed === 0) return; // Nothing to save
+    const unclaimedSaves = this.savesUnclaimed;
+    this.savesUnclaimed = 0;
 
     /* Called after a successful save. Fires the saving event if needed */
     const onSaved = () => {
       const wasSaving = this.saving;
-      this.saveCounter -= outstandingSaves;
+      this.savesOutstanding -= unclaimedSaves;
       if (this.status === ConnectionStatus.Connected && wasSaving !== this.saving)
         this.emit(SupabaseProviderEvents.Saving, this, this.saving);
     };
@@ -364,83 +391,102 @@ export class SupabaseProvider extends EventEmitter {
   }
 
   /**
-   * Sends a document update message to peers.
-   * @param message A YJS document update
-   */
-  private sendDocumentUpdate(message: Uint8Array) {
-    if (this.alone) return;
-    if (this.config.rw === ReadWriteMode.ReadOnly) return;
-    if (this.status === ConnectionStatus.Connected && this.channel)
-      this.channel.send({
-        type: "broadcast",
-        event: ChannelEvents.Message,
-        payload: Array.from(message),
-      });
-  }
-
-  /**
-   * Receives a document update message from peers and updates the local document state.
-   * @param message A YJS document update
-   */
-  private receiveDocumentUpdate(message: Uint8Array) {
-    try {
-      Y.applyUpdate(this.doc, message, this);
-    } catch (err: any) {
-      this.logger("Error applying remote document update", err);
-    }
-  }
-
-  /**
-   * Sends an awareness update message to peers.
-   * @param message A YJS awareness update
-   */
-  private sendAwarenessUpdate(message: Uint8Array) {
-    if (this.alone) return;
-    if (this.config.rw === ReadWriteMode.ReadOnly) return;
-    if (this.status === ConnectionStatus.Connected && this.channel)
-      this.channel.send({
-        type: "broadcast",
-        event: ChannelEvents.Awareness,
-        payload: Array.from(message),
-      });
-  }
-
-  /**
-   * Receives an awareness update message from peers and updates the local awareness state.
-   * @param message A YJS awareness update.
-   */
-  private receiveAwarenessUpdate(message: Uint8Array) {
-    try {
-      AwarenessProtocol.applyAwarenessUpdate(this.awareness, message, this);
-    } catch (error: any) {
-      this.logger("Error applying remote awareness update", error);
-    }
-  }
-
-  /**
    * Sends an update to all peers with the current state of the document.
    * By calling this periodically, we can avoid peers' local document state from diverging.
    */
   private sendResyncUpdate() {
     if (!this.config.resync) return;
     const update = Y.encodeStateAsUpdate(this.doc);
-    this.sendDocumentUpdate(update);
+    this.sendUpdate({ document: update });
+  }
+
+  /**
+   * Enqueues updates to send to peers. Updates are batched together and sent as a single message
+   * to clients depdening on the `throttleInterval`.
+   * @param update An object containing updates to enqueue.
+   * `document` contains a YJS update blob, `awareness` contains a list of changed clients.
+   */
+  private sendUpdate(update: { document?: Uint8Array; awareness?: number[] }) {
+    if (this.config.rw === ReadWriteMode.ReadOnly) return;
+    if (!update.document && (!update.awareness || update.awareness.length === 0)) return;
+    if (update.document) this.documentUpdates.push(update.document);
+    if (update.awareness) this.awarenessUpdates.push(...update.awareness);
+    this.throttledSend();
+  }
+
+  /**
+   * Sends all enqueued document/awareness updates as one combined Realtime broadcast.
+   * If there is nothing to send, does nothing. Enqueue
+   */
+  private commitUpdates() {
+    if (this.alone) return;
+    if (this.status !== ConnectionStatus.Connected) return;
+    if (!this.channel) return;
+    if (this.documentUpdates.length === 0 && this.awarenessUpdates.length === 0) return;
+
+    const payload: Payload = {};
+
+    if (this.documentUpdates.length > 0) {
+      payload.document = Array.from(Y.mergeUpdates(this.documentUpdates));
+      this.documentUpdates.length = 0;
+    }
+
+    if (this.awarenessUpdates.length > 0) {
+      const clients = uniq(this.awarenessUpdates);
+      this.awarenessUpdates.length = 0;
+      payload.awareness = Array.from(AwarenessProtocol.encodeAwarenessUpdate(this.awareness, clients));
+    }
+
+    this.channel.send({
+      type: "broadcast",
+      event: ChannelEvents.Update,
+      payload,
+    });
+  }
+
+  /**
+   * Receives an update from peers and applies it to the document.
+   * Invalid updates are ignored.
+   * @param update An update from peers
+   */
+  private receiveUpdate(update: Payload) {
+    const validation = PayloadSchema.safeParse(update);
+    if (!validation.success) return;
+    update = validation.data;
+
+    try {
+      if (update.awareness)
+        AwarenessProtocol.applyAwarenessUpdate(this.awareness, Uint8Array.from(update.awareness), this);
+      if (update.document) Y.applyUpdate(this.doc, Uint8Array.from(update.document), this);
+    } catch (err: any) {
+      this.logger("Error applying remote document update", err);
+    }
   }
 
   private onDocumentUpdate(update: Uint8Array, origin: any) {
     if (origin === this) return;
-    this.sendDocumentUpdate(update);
+    this.sendUpdate({ document: update });
     this.requestSave();
   }
 
-  private onAwarenessUpdate({ added, updated, removed }: any, origin: any) {
+  private onAwarenessUpdate(
+    {
+      added,
+      updated,
+      removed,
+    }: {
+      added: number[];
+      updated: number[];
+      removed: number[];
+    },
+    origin: any
+  ) {
     if (origin === this) return;
-    const changedClients = added.concat(updated).concat(removed);
-    const awarenessUpdate = AwarenessProtocol.encodeAwarenessUpdate(this.awareness, changedClients);
-    this.sendAwarenessUpdate(awarenessUpdate);
+    const clients = added.concat(updated).concat(removed);
+    this.sendUpdate({ awareness: clients });
   }
 
   private onUnload() {
-    AwarenessProtocol.removeAwarenessStates(this.awareness, [this.doc.clientID], this);
+    AwarenessProtocol.removeAwarenessStates(this.awareness, [this.doc.clientID], null);
   }
 }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -60,7 +60,9 @@ export type SupabaseProviderConfig = {
   readonly resyncInterval: number;
 
   /**
-   * How often to save the document in milliseconds. Must be positive.
+   * After modifying the document, how much time must pass in milliseconds 
+   * without making any changes before document updates are saved. In other words, document
+   * saves will be debounced by this interval. Must be positive.
    * @default 2500
    */
   readonly saveInterval: number;
@@ -354,6 +356,7 @@ export class SupabaseProvider extends EventEmitter {
   /**
    * Saves the document remotely to the database.
    * This should be debounced to save on database egress.
+   * @param [requireConnection=true] Whether or not the provider must be connected to save.
    */
   private async saveDocument(requireConnection: boolean = true) {
     if (requireConnection && this.status !== ConnectionStatus.Connected) return;
@@ -416,7 +419,7 @@ export class SupabaseProvider extends EventEmitter {
 
   /**
    * Sends all enqueued document/awareness updates as one combined Realtime broadcast.
-   * If there is nothing to send, does nothing. Enqueue
+   * If there is nothing to send, does nothing. Enqueue updates with {@link sendUpdate}.
    */
   private commitUpdates() {
     if (this.alone) return;

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -9,6 +9,18 @@ import { debounce, defaults } from "lodash";
 const DefaultResyncMs = 20000;
 const DefaultSaveMs = 2500;
 
+export enum ReadWriteMode {
+  /**
+   * Document is read/writable. Changes will be propogated to peers.
+   */
+  ReadWrite,
+
+  /**
+   * Document is read only. Changes won't be propogated to peers.
+   */
+  ReadOnly
+}
+
 export type SupabaseProviderConfig = {
   /** Name of the Supabase channel to connect to. */
   readonly channel: string;
@@ -56,6 +68,11 @@ export type SupabaseProviderConfig = {
    * @default true
    */
   readonly log: boolean;
+
+  /**
+   * The policy for reading/writing to the document.
+   */
+  rw: ReadWriteMode;
 };
 
 export enum SupabaseProviderEvents {
@@ -201,7 +218,8 @@ export class SupabaseProvider extends EventEmitter {
         resync: true,
         resyncInterval: DefaultResyncMs,
         saveInterval: DefaultSaveMs,
-        log: true
+        log: true,
+        rw: ReadWriteMode.ReadWrite
       }
     );
 
@@ -351,6 +369,7 @@ export class SupabaseProvider extends EventEmitter {
    */
   private sendDocumentUpdate(message: Uint8Array) {
     if (this.alone) return;
+    if (this.config.rw === ReadWriteMode.ReadOnly) return;
     if (this.status === ConnectionStatus.Connected && this.channel)
       this.channel.send({
         type: "broadcast",
@@ -377,6 +396,7 @@ export class SupabaseProvider extends EventEmitter {
    */
   private sendAwarenessUpdate(message: Uint8Array) {
     if (this.alone) return;
+    if (this.config.rw === ReadWriteMode.ReadOnly) return;
     if (this.status === ConnectionStatus.Connected && this.channel)
       this.channel.send({
         type: "broadcast",

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -402,7 +402,7 @@ export class SupabaseProvider extends EventEmitter {
    *  - Setting `resync` to true will send an update that synchronizes peers' document
    *    state, overwriting `document` and `awareness` if defined.
    */
-  private sendUpdate(update: { document?: Uint8Array; awareness?: number[], resync?: boolean }) {
+  private sendUpdate(update: { document?: Uint8Array; awareness?: number[]; resync?: boolean }) {
     if (!update.resync && this.config.rw === ReadWriteMode.ReadOnly) return;
     if (update.resync && !this.config.resync) return;
     if (update.resync) update = { document: Y.encodeStateAsUpdate(this.doc) };
@@ -485,6 +485,6 @@ export class SupabaseProvider extends EventEmitter {
   }
 
   private onUnload() {
-    AwarenessProtocol.removeAwarenessStates(this.awareness, [this.doc.clientID], null);
+    AwarenessProtocol.removeAwarenessStates(this.awareness, [this.doc.clientID], "unload");
   }
 }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -60,7 +60,7 @@ export type SupabaseProviderConfig = {
   readonly resyncInterval: number;
 
   /**
-   * After modifying the document, how much time must pass in milliseconds 
+   * After modifying the document, how much time must pass in milliseconds
    * without making any changes before document updates are saved. In other words, document
    * saves will be debounced by this interval. Must be positive.
    * @default 2500
@@ -136,7 +136,7 @@ export class SupabaseProvider extends EventEmitter {
     this.logger(`Creating ${SupabaseProvider.name} for document ${this.doc.guid}`);
 
     /* Set up resyncInterval */
-    this.resync = setInterval(this.sendResyncUpdate.bind(this), this.config.resyncInterval);
+    this.resync = setInterval(() => this.sendUpdate({ resync: true }), this.config.resyncInterval);
 
     /* Setup debounced save function */
     this.saveDocument = this.saveDocument.bind(this);
@@ -184,7 +184,7 @@ export class SupabaseProvider extends EventEmitter {
         /* If we're not alone and we received a presence update, then somebody new has joined.
          * We should send them the current state of the document in case our local changes haven't been saved */
         if (!this.alone) {
-          this.sendResyncUpdate();
+          this.sendUpdate({ resync: true });
           this.commitUpdates();
         }
       })
@@ -394,23 +394,18 @@ export class SupabaseProvider extends EventEmitter {
   }
 
   /**
-   * Sends an update to all peers with the current state of the document.
-   * By calling this periodically, we can avoid peers' local document state from diverging.
-   */
-  private sendResyncUpdate() {
-    if (!this.config.resync) return;
-    const update = Y.encodeStateAsUpdate(this.doc);
-    this.sendUpdate({ document: update });
-  }
-
-  /**
    * Enqueues updates to send to peers. Updates are batched together and sent as a single message
    * to clients depdening on the `throttleInterval`.
    * @param update An object containing updates to enqueue.
-   * `document` contains a YJS update blob, `awareness` contains a list of changed clients.
+   *  - `document` contains a YJS update blob
+   *  - `awareness` contains a list of changed clients.
+   *  - Setting `resync` to true will send an update that synchronizes peers' document
+   *    state, overwriting `document` and `awareness` if defined.
    */
-  private sendUpdate(update: { document?: Uint8Array; awareness?: number[] }) {
-    if (this.config.rw === ReadWriteMode.ReadOnly) return;
+  private sendUpdate(update: { document?: Uint8Array; awareness?: number[], resync?: boolean }) {
+    if (!update.resync && this.config.rw === ReadWriteMode.ReadOnly) return;
+    if (update.resync && !this.config.resync) return;
+    if (update.resync) update = { document: Y.encodeStateAsUpdate(this.doc) };
     if (!update.document && (!update.awareness || update.awareness.length === 0)) return;
     if (update.document) this.documentUpdates.push(update.document);
     if (update.awareness) this.awarenessUpdates.push(...update.awareness);
@@ -458,9 +453,9 @@ export class SupabaseProvider extends EventEmitter {
     update = validation.data;
 
     try {
+      if (update.document) Y.applyUpdate(this.doc, Uint8Array.from(update.document), this);
       if (update.awareness)
         AwarenessProtocol.applyAwarenessUpdate(this.awareness, Uint8Array.from(update.awareness), this);
-      if (update.document) Y.applyUpdate(this.doc, Uint8Array.from(update.document), this);
     } catch (err: any) {
       this.logger("Error applying remote document update", err);
     }

--- a/src/state/events.ts
+++ b/src/state/events.ts
@@ -1,3 +1,0 @@
-export enum RoomChannelEvents {
-  Update = "update",
-}

--- a/src/state/room.ts
+++ b/src/state/room.ts
@@ -6,7 +6,7 @@ import debug from "debug";
 import { ConnectionStatus } from "../types/Connection";
 import { type LiveUser, useUserState } from "./user";
 import { enqueueSnackbar } from "notistack";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { ChannelEvents } from "../provider/events";
 import { useRouter } from "@/components/navigation/AppProgressBar";
@@ -135,8 +135,8 @@ export const useRoomState = create<RoomState>((set, get) => ({
 
 export function useRoom(room: Room) {
   const router = useRouter();
-  const userState = useUserState();
   const roomState = useRoomState();
+  const userState = useUserState();
 
   /* Connect to room on mount, disconnect on unmount */
   useEffect(() => {
@@ -153,9 +153,17 @@ export function useRoom(room: Room) {
   useEffect(() => {
     if (userState.user.group > 0 && !room.groups.some((g) => g.no === userState.user.group)) {
       userState.updateUser({ group: 0 });
-      enqueueSnackbar("The host closed your group.");
+      enqueueSnackbar("The host closed your group");
     }
   }, [room, userState]);
+
+  /* Notify guests when host locks the room */
+  const wasLocked = useRef(room.locked);
+  useEffect(() => {
+    if (room.locked === wasLocked.current) return;
+    wasLocked.current = room.locked;
+    if (!userState.user.isHost && room.locked) enqueueSnackbar("The host locked the room");
+  }, [room.locked]);
 
   /* Attempt to reconnect on document becoming visible */
   useEffect(() => {

--- a/src/state/room.ts
+++ b/src/state/room.ts
@@ -8,7 +8,7 @@ import { type LiveUser, useUserState } from "./user";
 import { enqueueSnackbar } from "notistack";
 import { useEffect } from "react";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
-import { RoomChannelEvents } from "./events";
+import { ChannelEvents } from "../provider/events";
 import { useRouter } from "@/components/navigation/AppProgressBar";
 import { prod } from "@/app/util";
 
@@ -80,7 +80,7 @@ export const useRoomState = create<RoomState>((set, get) => ({
 
         set({ users });
       })
-      .on("broadcast", { event: RoomChannelEvents.Update }, () => {
+      .on("broadcast", { event: ChannelEvents.Update }, () => {
         logger("Notified of update to current room.");
         router.refresh();
       })

--- a/src/types/Room.ts
+++ b/src/types/Room.ts
@@ -70,6 +70,7 @@ export const RoomSchema = z.object({
     .max(8, "For performance reasons, you can't have more than 8 groups")
     .refine((arr) => new Set(arr.map((g) => g.no)).size === arr.length, "Can't have duplicate group numbers"),
   created: z.string().datetime(),
+  locked: z.boolean()
 });
 
 export const RoomSchemaNew = RoomSchema.extend({


### PR DESCRIPTION
## Room Lock

Allow hosts to lock rooms, preventing guests from modifying the room code. This also allows hosts to share persistent links to the room without worrying about it being modified later.

### Database Changes

- Add `lock_time` column to database. If `NULL`, the room is not locked. Otherwise, this is the timestamp that the room was locked at.
- Make `created` column a `timestamptz` to be consistent with Postgres best practices

### Other Changes

- Throttle Realtime document updates over a 200ms window (configurable)
  - This should greatly reduce the number of messages sent
- Batch both document and user awareness updates into single update message
- Resync awareness updates on client join
  - Guests will see the latest cursor positions/selections on join